### PR TITLE
use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/bin/sifdecoder
+++ b/bin/sifdecoder
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # sifdecoder: script to decode a sif file
 #
 #  N. Gould, D. Orban & Ph. Toint, November 7th, 2000


### PR DESCRIPTION
This was causing trouble on FreeBSD because `bash` is located at `/usr/local/bin/bash`. However, `/usr/bin/env bash` works. Can you foresee this causing problems on other systems? I only need to change the `sifdecoder` script, but I'm happy to change all scripts.