### PR TITLE
Release 2.6.0

### DIFF
--- a/.github/julia/build_tarballs.jl
+++ b/.github/julia/build_tarballs.jl
@@ -47,8 +47,7 @@ platforms = expand_gfortran_versions(platforms)
 
 # The products that we will ensure are always built
 products = [
-    LibraryProduct("libsifdecode", :libsifdecode),
-    ExecutableProduct("sifdecoder_standalone", :sifdecoder_standalone),
+   ExecutableProduct("sifdecoder_standalone", :sifdecoder_standalone),
 ]
 
 # Dependencies that must be installed before this package can be built

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,12 @@
 project(
   'SIFDecode',
   'fortran',
-  version: '2.5.1',
+  version: '2.6.0',
   meson_version: '>= 0.61.0',
   default_options: [
     'buildtype=release',
     'libdir=lib',
-    'default_library=shared',
+    'default_library=static',
     'warning_level=0',
   ],
 )

--- a/src/decode/sifdecode.f90
+++ b/src/decode/sifdecode.f90
@@ -25,7 +25,7 @@
 !  V e r s i o n
 !---------------
 
-      CHARACTER ( LEN = 6 ) :: version = '2.5.1 '
+      CHARACTER ( LEN = 6 ) :: version = '2.6.0 '
 
 !--------------------
 !   P r e c i s i o n


### PR DESCRIPTION
@jfowkes I also changed the default "mode" of the library so that we compile a static `libsifdecode.a` instead of a shared library `libsifdecode.${dlext}`.
For this package, we only want the binary `sifdecoder_standalone`, so it's better to directly embed `libsifdecode.a` in it.
This will allow you to store a binary `sifdecoder_standalone` / `sifdecoder_standalone.exe` for the main platforms in `PyCUTEst` and avoid requiring the user to compile `SIFDecode`.
