### PR TITLE
Try the sifdecoder on Mac Silicon

### DIFF
--- a/.github/workflows/sifdecoder.yml
+++ b/.github/workflows/sifdecoder.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: ['11']
+        version: ['12']
         problems: ['sifcollection', 'maros-meszaros', 'netlib-lp']
         precision: ['single', 'double', 'quadruple']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sifdecoder.yml
+++ b/.github/workflows/sifdecoder.yml
@@ -7,11 +7,11 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: ${{ matrix.problems }} -- ${{ matrix.precision }} precision
+    name: ${{ matrix.os }} -- ${{ matrix.problems }} -- ${{ matrix.precision }} precision
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         version: ['12']
         problems: ['sifcollection', 'maros-meszaros', 'netlib-lp']
         precision: ['single', 'double', 'quadruple']

--- a/.github/workflows/sifdecoder.yml
+++ b/.github/workflows/sifdecoder.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: ['12']
+        version: ['11']
         problems: ['sifcollection', 'maros-meszaros', 'netlib-lp']
         precision: ['single', 'double', 'quadruple']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I have some issues with the `sifdecoder_standalone` on Apple Silicon.
I suspect that we need a very recent `gfortran` compiler on this platform.

Related issue: https://github.com/iains/gcc-darwin-arm64/issues/5