### PR TITLE
Add a CI script sif_database.yml

### DIFF
--- a/.github/workflows/sif_database.yml
+++ b/.github/workflows/sif_database.yml
@@ -1,0 +1,58 @@
+name: CLASS.DB
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Verify SIF files and CLASSF.DB consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SIFDecode
+        uses: actions/checkout@v4
+
+      - name: Download the CUTEst NLP test set
+        shell: bash
+        run: |
+          cd $GITHUB_WORKSPACE/../
+          git clone https://bitbucket.org/optrove/sif
+
+      - name: Check entries in CLASSF.DB and SIF files
+        shell: bash
+        run: |
+          cd $GITHUB_WORKSPACE/../sif
+
+          # Read the CLASSF.DB file and store the problem names in an array
+          mapfile -t db_problems < <(awk '{print $1}' CLASSF.DB)
+
+          # Initialize counters for missing files and missing DB entries
+          missing_sif_count=0
+          missing_db_count=0
+
+          # Check if each SIF file has an entry in CLASSF.DB
+          for file in *.SIF; do
+            problem_name="${file%.SIF}"
+            if [[ " ${db_problems[*]} " != *" ${problem_name} "* ]]; then
+              echo "${problem_name} is ABSENT from CLASSF.DB"
+              missing_db_count=$((missing_db_count + 1))
+            fi
+          done
+
+          # Check if each entry in CLASSF.DB has a corresponding SIF file
+          for problem in "${db_problems[@]}"; do
+            if [[ ! -f "${problem}.SIF" ]]; then
+              echo "SIF file for ${problem} is MISSING"
+              missing_sif_count=$((missing_sif_count + 1))
+            fi
+          done
+
+          echo "Total number of SIF files without DB entries: ${missing_db_count}"
+          echo "Total number of DB entries without SIF files: ${missing_sif_count}"
+
+          # Exit with error if any issues were found
+          if [ "${missing_db_count}" -ne 0 ] || [ "${missing_sif_count}" -ne 0 ]; then
+            echo "Error: Mismatch between CLASSF.DB entries and SIF files"
+            exit 1
+          fi

--- a/.github/workflows/sifdecoder.yml
+++ b/.github/workflows/sifdecoder.yml
@@ -44,22 +44,15 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/../
           if [[ "${{ matrix.problems }}" == "sifcollection" ]]; then
-            # https://bitbucket.org/optrove/sif/downloads/?tab=branches
-            wget https://bitbucket.org/optrove/sif/get/c71425cc7f54ddda53ab57c11290a1cbf53aaf17.tar.gz
-            tar -xvzf c71425cc7f54ddda53ab57c11290a1cbf53aaf17.tar.gz
-            mv optrove-sif-c71425cc7f54 sif
+            git clone https://bitbucket.org/optrove/sif
           fi
           if [[ "${{ matrix.problems }}" == "maros-meszaros" ]]; then
-            # https://bitbucket.org/optrove/maros-meszaros/downloads/?tab=branches
-            wget https://bitbucket.org/optrove/maros-meszaros/get/9adfb5707b1e0b83a2e0a26cc8310704ff01b7c1.tar.gz
-            tar -xvzf 9adfb5707b1e0b83a2e0a26cc8310704ff01b7c1.tar.gz
-            mv optrove-maros-meszaros-9adfb5707b1e sif
+            git clone https://bitbucket.org/optrove/maros-meszaros
+            mv maros-meszaros sif
           fi
           if [[ "${{ matrix.problems }}" == "netlib-lp" ]]; then
-            # https://bitbucket.org/optrove/netlib-lp/downloads/?tab=branches
-            wget https://bitbucket.org/optrove/netlib-lp/get/f83996fca9370b23d8896f134c4dfe7adbaca0ec.tar.gz
-            tar -xvzf f83996fca9370b23d8896f134c4dfe7adbaca0ec.tar.gz
-            mv optrove-netlib-lp-f83996fca937 sif
+            git clone https://bitbucket.org/optrove/netlib-lp
+            mv netlib-lp sif
           fi
 
       - name: SIFDecode


### PR DESCRIPTION
@jfowkes @nimgould 

- **Update `sifdecoder.yml`**: Ensure that it always downloads the latest versions of the `sif`, `maros-meszaros`, and `netlib-lp` sets. There’s no need to update this if you add new SIF files in the future.

- **Add a CI script `sif_database.yml`**: Create a build to verify consistency between the SIF files in the `sif` set and the entries in `CLASSF.DB` (see #26).

Result of the CI build: [here](https://github.com/ralna/SIFDecode/actions/runs/10588271540/job/29340499828?pr=27)